### PR TITLE
Update For GCC Testing and Dataflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The extension supports the following VSCode settings:
 |-------|-----------|-------------|
 |`powerbi.tenantId`|The tenant ID of the remote tenant that you want to connect to.|A GUID, `abcd1234-1234-5678-9abcd-9d1963e4b9f5`|
 |`powerbi.clientId`|(Optional) A custom ClientID/Application of an AAD application to use when connecting to Power BI.|A GUID, `99887766-1234-5678-9abcd-e4b9f59d1963`|
-|`powerbi.cloud`|(Optional) Onnly use when you want to connect to a sovereign or governmental cloud!|GlobalCloud|
+|`powerbi.cloud`|(Optional) Only use when you want to connect to a sovereign or governmental cloud!|GlobalCloud|
 
 # Notebooks
 You can open a new Power BI notebook via the UI from the header of each treeview or by running the command __Open new PowerBI Notebook__ (command `PowerBI.openNewNotebook`). Power BI notebooks have the file extension `.pbinb` and will automatically open in the notebook editor.
@@ -88,9 +88,10 @@ Current values of variables can be retrieved by running `SET MY_VARIABLE`.
 # Building Locally
 1. Make sure you have installed [NodeJS](https://nodejs.org/en/) on your development workstation
 2. Clone this repo to your development workstation, then open the cloned folder in [VSCode](https://code.visualstudio.com/)
-3. To install all dependencies, switch to the terminal and run `npm install`
-4. To run the extension in debug mode (for using break-points, etc.), press `F5`
-5. To generate the `.vsix`, switch to the terminal and run `vsce package`
+3. Install Visual Studio Code Extension Manager by running `npm install @vscode/vsce -g --force`
+4. To install all dependencies, switch to the terminal and run `npm install`
+5. To run the extension in debug mode (for using break-points, etc.), press `F5`
+6. To generate the `.vsix`, switch to the terminal and run `vsce package`
 
 # VSCode Extension Development Details
 Please refer to the [official docs and samples](https://github.com/microsoft/vscode-extension-samples#prerequisites)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "powerbi-vscode",
 	"displayName": "Power BI VSCode",
 	"description": "Power BI Extension for VSCode",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"publisher": "GerhardBrueckl",
 	"icon": "resources/powerbi_extension.png",
 	"author": {

--- a/src/ThisExtension.ts
+++ b/src/ThisExtension.ts
@@ -7,7 +7,7 @@ import { PowerBICapacitiesTreeProvider } from './vscode/treeviews/Capacities/Pow
 import { PowerBIGatewaysTreeProvider } from './vscode/treeviews/Gateways/PowerBIGatewaysTreeProvider';
 import { PowerBIPipelinesTreeProvider } from './vscode/treeviews/Pipelines/PowerBIPipelinesTreeProvider';
 import { PowerBIWorkspacesTreeProvider } from './vscode/treeviews/workspaces/PowerBIWorkspacesTreeProvider';
-import { PowerBIConfiugration } from './vscode/configuration/PowerBIConfiguration';
+import { PowerBIConfiguration } from './vscode/configuration/PowerBIConfiguration';
 
 
 export type TreeProviderId = 
@@ -140,7 +140,7 @@ export abstract class ThisExtension {
 				this._settingScope = "Global";
 			}
 
-			let config = PowerBIConfiugration;
+			let config = PowerBIConfiguration;
 			config.applySettings();
 			await PowerBIApiService.initialize(config.apiUrl, config.tenantId, config.clientId, config.authenticationProvider, config.resourceId);
 

--- a/src/powerbi/PowerBIApiService.ts
+++ b/src/powerbi/PowerBIApiService.ts
@@ -27,10 +27,11 @@ export abstract class PowerBIApiService {
 
 	//#region Initialization
 	static async initialize(
+		// Default settings will be for Azure Global
 		apiBaseUrl: string = "https://api.powerbi.com/",
 		tenantId: string = undefined,
 		clientId: string = undefined,
-		authenticatinProvider: string = "microsoft",
+		authenticationProvider: string = "microsoft",
 		resourceId: string = "https://analysis.windows.net/powerbi/api"
 	): Promise<boolean> {
 		try {
@@ -41,7 +42,7 @@ export abstract class PowerBIApiService {
 			this._apiBaseUrl = Helper.trimChar(apiBaseUrl, '/');
 			this._tenantId = tenantId;
 			this._clientId = clientId;
-			this._authenticationProvider = authenticatinProvider;
+			this._authenticationProvider = authenticationProvider;
 			this._resourceId = resourceId;
 
 			await this.refreshHeaders();

--- a/src/vscode/configuration/PowerBIConfiguration.ts
+++ b/src/vscode/configuration/PowerBIConfiguration.ts
@@ -43,8 +43,8 @@ const CLOUD_CONFIGS: { [key: string]: iCloudConfig } = {
 	},
 	"USGovCloud": {
 		"friendlyName": "US Government Community Cloud (GCC)",
-		"authenticationProvider": "microsoft-sovereign-cloud",
-		"authenticationEndpoint": "https://login.microsoftonline.com/common",
+		"authenticationProvider": "microsoft",
+		"authenticationEndpoint": "https://login.windows.net/common",
 		"apiEndpoint": "https://api.powerbigov.us",
 		"resourceId": "https://analysis.usgovcloudapi.net/powerbi/api",
 		"allowedDomains": ["*.analysis.usgovcloudapi.net"]
@@ -84,7 +84,7 @@ const CLOUD_CONFIGS: { [key: string]: iCloudConfig } = {
 }
 
 
-export abstract class PowerBIConfiugration {
+export abstract class PowerBIConfiguration {
 	static get cloud(): string { return this.getValue("cloud"); }
 	static set cloud(value: string) { this.setValue("cloud", value); }
 
@@ -103,7 +103,9 @@ export abstract class PowerBIConfiugration {
 	static get resourceId(): string { return CLOUD_CONFIGS[this.cloud].resourceId; }
 
 	static get isSovereignCloud(): boolean {
-		return this.authenticationProvider === "microsoft-sovereign-cloud";
+		// If the base URL for the API is not pointed to api.powerbi.com assume 
+		// we are pointed to the sovereign tenant
+		return this.apiUrl !== "https://api.powerbi.com/"
 	}
 
 	static get config(): vscode.WorkspaceConfiguration {

--- a/src/vscode/treeviews/workspaces/PowerBIDataflows.ts
+++ b/src/vscode/treeviews/workspaces/PowerBIDataflows.ts
@@ -43,7 +43,7 @@ export class PowerBIDataflows extends PowerBIWorkspaceTreeItem {
 		}
 		else {
 			let children: PowerBIDataflow[] = [];
-			let items: iPowerBIDataflow[] = await PowerBIApiService.getItemList<iPowerBIDataflow>(this.apiPath, {}, "displayName");
+			let items: iPowerBIDataflow[] = await PowerBIApiService.getItemList<iPowerBIDataflow>(this.apiPath, {}, "name");
 
 			for (let item of items) {
 				let treeItem = new PowerBIDataflow(item, this.groupId, this);


### PR DESCRIPTION
With the current version, I could not get it to work in a few GCC tenants.  

After reviewing the code, I updated the configuration for USGovCloud and verified the configuration works in GCC.

In addition, when dataflows were expanded I was getting a "toString" on undefined property.  I updated the code to look for the "name" property.

I am unable to test other sovereign clouds at this time.

Please let me know if you have any questions or concerns. 