### PR TITLE
Fix for Dataflow Refreshes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "powerbi-vscode",
 	"displayName": "Power BI VSCode",
 	"description": "Power BI Extension for VSCode",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"publisher": "GerhardBrueckl",
 	"icon": "resources/powerbi_extension.png",
 	"author": {
@@ -448,7 +448,7 @@
 				},
 				{
 					"command": "PowerBIDashboard.delete",
-					"when": "view == PowerBIWorkspaces && viewItem =~ /.*,DATAFLOW,.*/",
+					"when": "view == PowerBIWorkspaces && viewItem =~ /.*,DASHBOARD,.*/",
 					"group": "inline"
 				},
 				{

--- a/src/vscode/treeviews/workspaces/PowerBIDataflow.ts
+++ b/src/vscode/treeviews/workspaces/PowerBIDataflow.ts
@@ -43,7 +43,11 @@ export class PowerBIDataflow extends PowerBIWorkspaceTreeItem {
 
 	public async refresh(): Promise<void> {
 		ThisExtension.setStatusBar("Triggering dataflow-refresh ...", true);
-		PowerBIApiService.post(this.apiPath + "/refreshes", null);
+		// Provide required notifyOption 
+		let body = {
+			"notifyOption": "MailOnFailure"
+		}
+		PowerBIApiService.post(this.apiPath + "refreshes", body);
 		ThisExtension.setStatusBar("Dataflow-refresh triggered");
 	}
 


### PR DESCRIPTION
Sorry I didn't see this yesterday, but the Power BI dataflows was showing two delete buttons and the refresh was not working.

After looking into it, I did the following:

1) Updated the configuration to move the delete option to the Dashboard area (which was missing).
2) Added the required "notifyOption" to the body of the dataflow refresh request.  This avoids the bad request that returns when an empty json body is sent via POST.

I tested in both Commercial and USGovCloud with these changes.